### PR TITLE
feat(bridge,maps): scaffold kachaka_autoware_bridge + maps packages

### DIFF
--- a/ros2/kachaka_autoware_bridge/CMakeLists.txt
+++ b/ros2/kachaka_autoware_bridge/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.14)
+project(kachaka_autoware_bridge)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros2/kachaka_autoware_bridge/launch/sensor_ouster.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/sensor_ouster.launch.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="sensor_hostname" default="os-122000000000.local"
+       description="Ouster OS-1 hostname or IP. Override per robot."/>
+  <arg name="metadata" default="/tmp/os1_metadata.json"
+       description="Path to ouster metadata cache"/>
+
+  <include file="$(find-pkg-share ouster_ros)/launch/sensor.launch.xml">
+    <arg name="sensor_hostname" value="$(var sensor_hostname)"/>
+    <arg name="metadata" value="$(var metadata)"/>
+  </include>
+
+  <node pkg="topic_tools" exec="relay" name="ouster_to_autoware_relay">
+    <param name="input_topic" value="/ouster/points"/>
+    <param name="output_topic" value="/sensing/lidar/top/pointcloud_raw_ex"/>
+  </node>
+
+  <node pkg="topic_tools" exec="relay" name="ouster_imu_relay">
+    <param name="input_topic" value="/ouster/imu"/>
+    <param name="output_topic" value="/sensing/imu/imu"/>
+  </node>
+</launch>

--- a/ros2/kachaka_autoware_bridge/launch/sensor_ouster.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/sensor_ouster.launch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="sensor_hostname" default="os-122000000000.local"
-       description="Ouster OS-1 hostname or IP. Override per robot."/>
+  <arg name="sensor_hostname" default="os-sensor.local"
+       description="Ouster OS-1 hostname or IP. Override per robot (e.g. os-&lt;serial&gt;.local)."/>
   <arg name="metadata" default="/tmp/os1_metadata.json"
        description="Path to ouster metadata cache"/>
 

--- a/ros2/kachaka_autoware_bridge/package.xml
+++ b/ros2/kachaka_autoware_bridge/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>kachaka_autoware_bridge</name>
+  <version>0.0.0</version>
+  <description>Top-level launch and integration glue connecting the Kachaka gRPC ROS 2 bridge to Autoware Core.</description>
+  <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="yutaka.kondo@youtalk.jp">Yutaka Kondo</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>launch_xml</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+
+  <exec_depend>kachaka_grpc_ros2_bridge</exec_depend>
+  <exec_depend>kachaka_autoware_description</exec_depend>
+  <exec_depend>kachaka_autoware_maps</exec_depend>
+
+  <exec_depend>ouster_ros</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2/kachaka_autoware_bridge/package.xml
+++ b/ros2/kachaka_autoware_bridge/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>kachaka_autoware_bridge</name>
   <version>0.0.0</version>
-  <description>Top-level launch and integration glue connecting the Kachaka gRPC ROS 2 bridge to Autoware Core.</description>
+  <description>Launch wrappers connecting Kachaka sensors to Autoware Core. Currently provides the Ouster OS-1 driver wrapper that publishes onto Autoware-expected topics; additional launches (localization, planning, control, integrated bringup) land in subsequent PRs.</description>
   <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
   <author email="yutaka.kondo@youtalk.jp">Yutaka Kondo</author>
@@ -13,11 +13,6 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch_xml</exec_depend>
   <exec_depend>topic_tools</exec_depend>
-
-  <exec_depend>kachaka_grpc_ros2_bridge</exec_depend>
-  <exec_depend>kachaka_autoware_description</exec_depend>
-  <exec_depend>kachaka_autoware_maps</exec_depend>
-
   <exec_depend>ouster_ros</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/ros2/kachaka_autoware_maps/CMakeLists.txt
+++ b/ros2/kachaka_autoware_maps/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.14)
+project(kachaka_autoware_maps)
+
+find_package(ament_cmake REQUIRED)
+
+install(FILES README.md DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros2/kachaka_autoware_maps/README.md
+++ b/ros2/kachaka_autoware_maps/README.md
@@ -1,0 +1,63 @@
+# kachaka_autoware_maps
+
+Map preparation guide for running Kachaka with Autoware Core. Map artifacts
+(`pointcloud_map.pcd` and `lanelet2_map.osm`) are not stored in this
+repository; they live under `~/maps/<location_name>/` on the user machine.
+
+## Prerequisites
+
+- Ouster OS-1 128 (or any equivalent 3D LiDAR) is rigidly mounted on the
+  Kachaka shelf top.
+- The `ouster-ros` driver can publish point clouds and IMU samples.
+- The Kachaka 2D LiDAR is **not** used in this pipeline (the home unit's 2D
+  LiDAR is broken — the Autoware integration intentionally bypasses it).
+
+## Directory layout
+
+```
+~/maps/<location_name>/
+├── pointcloud_map.pcd
+├── pointcloud_map/
+│   └── metadata.yaml
+├── lanelet2_map.osm
+└── map_projector_info.yaml
+```
+
+Pass these paths to the `autoware_core_map.launch.xml` arguments
+`pointcloud_map_path`, `pointcloud_map_metadata_path`, `lanelet2_map_path`,
+and `map_projector_info_path`.
+
+## 1. pointcloud_map.pcd
+
+Run a 3D SLAM pipeline using the OS-1 alone. The recommended tool is
+[`glim`](https://github.com/koide3/glim) on Jazzy. Drive Kachaka manually
+through the entire mappable area and close the loop back to the start point.
+
+## 2. lanelet2_map.osm
+
+Use the [TIER IV Vector Map Builder](https://tools.tier4.jp/vector_map_builder_ll2/)
+with the pointcloud_map loaded as background. Export with the same local
+projection origin as the pointcloud_map. Lane width should be roughly
+`0.6 m` (Kachaka body width 0.387 m + margin) and the speed limit
+`0.3 m/s`.
+
+## 3. map_projector_info.yaml
+
+```yaml
+projector_type: Local
+vertical_datum: WGS84
+```
+
+`Local` is the GNSS-free indoor configuration. It assumes the
+Vector Map Builder export used "Local Cartesian".
+
+## 4. pointcloud_map/metadata.yaml (single-tile layout)
+
+```yaml
+x_resolution: 50.0
+y_resolution: 50.0
+A.pcd: [0, 0]
+```
+
+Refer to the `autoware_map_loader` documentation for the full schema if you
+later split the map into multiple tiles.

--- a/ros2/kachaka_autoware_maps/README.md
+++ b/ros2/kachaka_autoware_maps/README.md
@@ -9,8 +9,8 @@ repository; they live under `~/maps/<location_name>/` on the user machine.
 - Ouster OS-1 128 (or any equivalent 3D LiDAR) is rigidly mounted on the
   Kachaka shelf top.
 - The `ouster-ros` driver can publish point clouds and IMU samples.
-- The Kachaka 2D LiDAR is **not** used in this pipeline (the home unit's 2D
-  LiDAR is broken — the Autoware integration intentionally bypasses it).
+- The pipeline uses the 3D LiDAR exclusively for both mapping and
+  localization; Kachaka's built-in 2D LiDAR is not part of this stack.
 
 ## Directory layout
 
@@ -56,8 +56,9 @@ Vector Map Builder export used "Local Cartesian".
 ```yaml
 x_resolution: 50.0
 y_resolution: 50.0
-A.pcd: [0, 0]
+pointcloud_map.pcd: [0, 0]
 ```
 
-Refer to the `autoware_map_loader` documentation for the full schema if you
-later split the map into multiple tiles.
+The map filename in the metadata must match the actual PCD file in the
+layout above. Refer to the `autoware_map_loader` documentation for the
+full schema if you later split the map into multiple tiles.

--- a/ros2/kachaka_autoware_maps/package.xml
+++ b/ros2/kachaka_autoware_maps/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>kachaka_autoware_maps</name>
+  <version>0.0.0</version>
+  <description>Documentation and helper layout for Kachaka Autoware map preparation (M0). Map files themselves live outside the repository.</description>
+  <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="yutaka.kondo@youtalk.jp">Yutaka Kondo</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Summary

Stack base for the Kachaka × Autoware Core integration. Adds two new ROS 2 packages used by all downstream stacks:

- `kachaka_autoware_maps` — documentation-only package describing how to lay out `pointcloud_map.pcd` / `lanelet2_map.osm` under `~/maps/<location_name>/`. The map artifacts themselves stay outside the repo (Task 5 of the MVP plan).
- `kachaka_autoware_bridge` — empty meta-package scaffold + `sensor_ouster.launch.xml` that wraps the ouster-ros driver and relays `/ouster/{points,imu}` to the Autoware-expected `/sensing/lidar/top/pointcloud_raw_ex` and `/sensing/imu/imu` topics (Task 10).

The integrated launch tree, vehicle interface, localization/planning/control launches will land as stacked PRs on top of this branch.

## Test plan

- [x] `colcon build --packages-select kachaka_autoware_maps kachaka_autoware_bridge` on Jazzy → 2 packages finished, no errors.
- [x] `colcon test` → linter / xmllint / copyright / cmake_lint pass.
- [x] `xmllint --noout sensor_ouster.launch.xml` OK.
- [ ] `ros2 launch kachaka_autoware_bridge sensor_ouster.launch.xml` against a live OS-1 (deferred — needs hardware).