### PR TITLE
feat(vehicle_interface): pure-logic libraries with gtest

### DIFF
--- a/ros2/kachaka_autoware_vehicle_interface/CMakeLists.txt
+++ b/ros2/kachaka_autoware_vehicle_interface/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.14)
+project(kachaka_autoware_vehicle_interface)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/control_to_twist_converter.cpp
+  src/operation_mode_state_machine.cpp
+  src/velocity_status_publisher.cpp
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_control_to_twist_converter
+    test/test_control_to_twist_converter.cpp
+  )
+  target_link_libraries(test_control_to_twist_converter ${PROJECT_NAME})
+
+  ament_add_gtest(test_operation_mode_state_machine
+    test/test_operation_mode_state_machine.cpp
+  )
+  target_link_libraries(test_operation_mode_state_machine ${PROJECT_NAME})
+
+  ament_add_gtest(test_velocity_status_publisher
+    test/test_velocity_status_publisher.cpp
+  )
+  target_link_libraries(test_velocity_status_publisher ${PROJECT_NAME})
+endif()
+
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/control_to_twist_converter.hpp
+++ b/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/control_to_twist_converter.hpp
@@ -1,0 +1,44 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KACHAKA_AUTOWARE_VEHICLE_INTERFACE__CONTROL_TO_TWIST_CONVERTER_HPP_
+#define KACHAKA_AUTOWARE_VEHICLE_INTERFACE__CONTROL_TO_TWIST_CONVERTER_HPP_
+
+#include <autoware_control_msgs/msg/control.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+
+namespace kachaka_autoware_vehicle_interface
+{
+
+struct ControlToTwistParams
+{
+  double wheel_base;
+  double max_linear_velocity;
+  double max_angular_velocity;
+};
+
+class ControlToTwistConverter
+{
+public:
+  explicit ControlToTwistConverter(const ControlToTwistParams & params);
+
+  geometry_msgs::msg::Twist convert(const autoware_control_msgs::msg::Control & control) const;
+
+private:
+  ControlToTwistParams params_;
+};
+
+}  // namespace kachaka_autoware_vehicle_interface
+
+#endif  // KACHAKA_AUTOWARE_VEHICLE_INTERFACE__CONTROL_TO_TWIST_CONVERTER_HPP_

--- a/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/operation_mode_state_machine.hpp
+++ b/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/operation_mode_state_machine.hpp
@@ -1,0 +1,46 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KACHAKA_AUTOWARE_VEHICLE_INTERFACE__OPERATION_MODE_STATE_MACHINE_HPP_
+#define KACHAKA_AUTOWARE_VEHICLE_INTERFACE__OPERATION_MODE_STATE_MACHINE_HPP_
+
+#include <mutex>
+
+namespace kachaka_autoware_vehicle_interface
+{
+
+enum class OperationMode
+{
+  STOP,
+  AUTONOMOUS,
+};
+
+class OperationModeStateMachine
+{
+public:
+  OperationModeStateMachine();
+
+  OperationMode get_state() const;
+
+  bool request_autonomous();
+  bool request_stop();
+
+private:
+  mutable std::mutex mutex_;
+  OperationMode state_;
+};
+
+}  // namespace kachaka_autoware_vehicle_interface
+
+#endif  // KACHAKA_AUTOWARE_VEHICLE_INTERFACE__OPERATION_MODE_STATE_MACHINE_HPP_

--- a/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/velocity_status_publisher.hpp
+++ b/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/velocity_status_publisher.hpp
@@ -1,0 +1,29 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KACHAKA_AUTOWARE_VEHICLE_INTERFACE__VELOCITY_STATUS_PUBLISHER_HPP_
+#define KACHAKA_AUTOWARE_VEHICLE_INTERFACE__VELOCITY_STATUS_PUBLISHER_HPP_
+
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+namespace kachaka_autoware_vehicle_interface
+{
+
+autoware_vehicle_msgs::msg::VelocityReport convert_odometry_to_velocity_report(
+  const nav_msgs::msg::Odometry & odom);
+
+}  // namespace kachaka_autoware_vehicle_interface
+
+#endif  // KACHAKA_AUTOWARE_VEHICLE_INTERFACE__VELOCITY_STATUS_PUBLISHER_HPP_

--- a/ros2/kachaka_autoware_vehicle_interface/package.xml
+++ b/ros2/kachaka_autoware_vehicle_interface/package.xml
@@ -3,21 +3,17 @@
 <package format="3">
   <name>kachaka_autoware_vehicle_interface</name>
   <version>0.0.0</version>
-  <description>Vehicle Interface bridging Autoware Core control output to Kachaka manual_control/cmd_vel, with operation_mode state machine and velocity_status republishing.</description>
+  <description>Pure-logic libraries used by the Kachaka Autoware vehicle interface: Ackermann-to-differential-drive twist conversion, operation-mode state machine, and odometry-to-VelocityReport conversion. The rclcpp Node that wires these into ROS I/O is added by a follow-up PR.</description>
   <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
   <author email="yutaka.kondo@youtalk.jp">Yutaka Kondo</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>rclcpp</depend>
-  <depend>rclcpp_components</depend>
-  <depend>std_srvs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>nav_msgs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
-  <depend>autoware_adapi_v1_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/ros2/kachaka_autoware_vehicle_interface/package.xml
+++ b/ros2/kachaka_autoware_vehicle_interface/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>kachaka_autoware_vehicle_interface</name>
+  <version>0.0.0</version>
+  <description>Vehicle Interface bridging Autoware Core control output to Kachaka manual_control/cmd_vel, with operation_mode state machine and velocity_status republishing.</description>
+  <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="yutaka.kondo@youtalk.jp">Yutaka Kondo</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>std_srvs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>autoware_control_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
+  <depend>autoware_adapi_v1_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2/kachaka_autoware_vehicle_interface/src/control_to_twist_converter.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/src/control_to_twist_converter.cpp
@@ -28,10 +28,21 @@ geometry_msgs::msg::Twist ControlToTwistConverter::convert(
 {
   const double v = static_cast<double>(control.longitudinal.velocity);
   const double delta = static_cast<double>(control.lateral.steering_tire_angle);
-  const double omega = (params_.wheel_base > 0.0) ? v * std::tan(delta) / params_.wheel_base : 0.0;
+
+  // Saturate linear velocity first, then derive omega from the clamped value
+  // so the (v, omega) pair preserves the curvature v*tan(delta)/L commanded by
+  // the controller. Computing omega from the unclamped v would make the robot
+  // turn much sharper than intended whenever the requested speed exceeds
+  // max_linear_velocity but the resulting omega still lies within its own
+  // saturation limit.
+  const double v_clamped =
+    std::clamp(v, -params_.max_linear_velocity, params_.max_linear_velocity);
+  const double omega = (params_.wheel_base > 0.0) ?
+    v_clamped * std::tan(delta) / params_.wheel_base :
+    0.0;
 
   geometry_msgs::msg::Twist twist;
-  twist.linear.x = std::clamp(v, -params_.max_linear_velocity, params_.max_linear_velocity);
+  twist.linear.x = v_clamped;
   twist.angular.z = std::clamp(omega, -params_.max_angular_velocity, params_.max_angular_velocity);
   return twist;
 }

--- a/ros2/kachaka_autoware_vehicle_interface/src/control_to_twist_converter.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/src/control_to_twist_converter.cpp
@@ -1,0 +1,39 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kachaka_autoware_vehicle_interface/control_to_twist_converter.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace kachaka_autoware_vehicle_interface
+{
+
+ControlToTwistConverter::ControlToTwistConverter(const ControlToTwistParams & params)
+: params_(params) {}
+
+geometry_msgs::msg::Twist ControlToTwistConverter::convert(
+  const autoware_control_msgs::msg::Control & control) const
+{
+  const double v = static_cast<double>(control.longitudinal.velocity);
+  const double delta = static_cast<double>(control.lateral.steering_tire_angle);
+  const double omega = (params_.wheel_base > 0.0) ? v * std::tan(delta) / params_.wheel_base : 0.0;
+
+  geometry_msgs::msg::Twist twist;
+  twist.linear.x = std::clamp(v, -params_.max_linear_velocity, params_.max_linear_velocity);
+  twist.angular.z = std::clamp(omega, -params_.max_angular_velocity, params_.max_angular_velocity);
+  return twist;
+}
+
+}  // namespace kachaka_autoware_vehicle_interface

--- a/ros2/kachaka_autoware_vehicle_interface/src/operation_mode_state_machine.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/src/operation_mode_state_machine.cpp
@@ -1,0 +1,43 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kachaka_autoware_vehicle_interface/operation_mode_state_machine.hpp"
+
+namespace kachaka_autoware_vehicle_interface
+{
+
+OperationModeStateMachine::OperationModeStateMachine()
+: state_(OperationMode::STOP) {}
+
+OperationMode OperationModeStateMachine::get_state() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return state_;
+}
+
+bool OperationModeStateMachine::request_autonomous()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  state_ = OperationMode::AUTONOMOUS;
+  return true;
+}
+
+bool OperationModeStateMachine::request_stop()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  state_ = OperationMode::STOP;
+  return true;
+}
+
+}  // namespace kachaka_autoware_vehicle_interface

--- a/ros2/kachaka_autoware_vehicle_interface/src/velocity_status_publisher.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/src/velocity_status_publisher.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kachaka_autoware_vehicle_interface/velocity_status_publisher.hpp"
+
+namespace kachaka_autoware_vehicle_interface
+{
+
+autoware_vehicle_msgs::msg::VelocityReport convert_odometry_to_velocity_report(
+  const nav_msgs::msg::Odometry & odom)
+{
+  autoware_vehicle_msgs::msg::VelocityReport report;
+  report.header = odom.header;
+  report.longitudinal_velocity = static_cast<float>(odom.twist.twist.linear.x);
+  // Differential drive: lateral velocity in body frame is identically zero.
+  report.lateral_velocity = 0.0f;
+  report.heading_rate = static_cast<float>(odom.twist.twist.angular.z);
+  return report;
+}
+
+}  // namespace kachaka_autoware_vehicle_interface

--- a/ros2/kachaka_autoware_vehicle_interface/src/velocity_status_publisher.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/src/velocity_status_publisher.cpp
@@ -21,7 +21,11 @@ autoware_vehicle_msgs::msg::VelocityReport convert_odometry_to_velocity_report(
   const nav_msgs::msg::Odometry & odom)
 {
   autoware_vehicle_msgs::msg::VelocityReport report;
-  report.header = odom.header;
+  // VelocityReport carries body-frame velocities, so the frame_id must match
+  // the frame Odometry's twist is expressed in (child_frame_id, e.g.
+  // base_link), not the pose frame (header.frame_id, e.g. odom/map).
+  report.header.stamp = odom.header.stamp;
+  report.header.frame_id = odom.child_frame_id;
   report.longitudinal_velocity = static_cast<float>(odom.twist.twist.linear.x);
   // Differential drive: lateral velocity in body frame is identically zero.
   report.lateral_velocity = 0.0f;

--- a/ros2/kachaka_autoware_vehicle_interface/test/test_control_to_twist_converter.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/test/test_control_to_twist_converter.cpp
@@ -1,0 +1,110 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <autoware_control_msgs/msg/control.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+
+#include "kachaka_autoware_vehicle_interface/control_to_twist_converter.hpp"
+
+using kachaka_autoware_vehicle_interface::ControlToTwistConverter;
+using kachaka_autoware_vehicle_interface::ControlToTwistParams;
+
+namespace
+{
+
+ControlToTwistParams make_default_params()
+{
+  ControlToTwistParams p;
+  p.wheel_base = 0.30;
+  p.max_linear_velocity = 0.3;
+  p.max_angular_velocity = 1.57;
+  return p;
+}
+
+autoware_control_msgs::msg::Control make_control(double v, double delta)
+{
+  autoware_control_msgs::msg::Control c;
+  c.longitudinal.velocity = static_cast<float>(v);
+  c.lateral.steering_tire_angle = static_cast<float>(delta);
+  return c;
+}
+
+}  // namespace
+
+TEST(ControlToTwistConverter, StraightLineHasZeroAngular)
+{
+  ControlToTwistConverter converter(make_default_params());
+  const auto twist = converter.convert(make_control(0.2, 0.0));
+  EXPECT_DOUBLE_EQ(twist.linear.x, static_cast<double>(static_cast<float>(0.2)));
+  EXPECT_DOUBLE_EQ(twist.angular.z, 0.0);
+}
+
+TEST(ControlToTwistConverter, RightTurnHasNegativeAngular)
+{
+  // delta = -0.3 rad (right turn), v = 0.2 m/s, wheel_base = 0.30
+  // omega = 0.2 * tan(-0.3) / 0.30
+  ControlToTwistConverter converter(make_default_params());
+  const auto twist = converter.convert(make_control(0.2, -0.3));
+  const double v_f = static_cast<double>(static_cast<float>(0.2));
+  const double delta_f = static_cast<double>(static_cast<float>(-0.3));
+  EXPECT_NEAR(twist.linear.x, v_f, 1e-6);
+  EXPECT_NEAR(twist.angular.z, v_f * std::tan(delta_f) / 0.30, 1e-6);
+  EXPECT_LT(twist.angular.z, 0.0);
+}
+
+TEST(ControlToTwistConverter, ClampLinearVelocityToMax)
+{
+  ControlToTwistConverter converter(make_default_params());
+  const auto twist = converter.convert(make_control(1.0, 0.0));
+  EXPECT_NEAR(twist.linear.x, 0.3, 1e-9);
+}
+
+TEST(ControlToTwistConverter, ClampAngularVelocityToMax)
+{
+  ControlToTwistConverter converter(make_default_params());
+  // Large delta yields a huge omega; clamped to max_angular_velocity.
+  const auto twist = converter.convert(make_control(0.3, 1.5));
+  EXPECT_NEAR(twist.angular.z, 1.57, 1e-6);
+}
+
+TEST(ControlToTwistConverter, NegativeLinearVelocityClampsAtNegativeMax)
+{
+  ControlToTwistConverter converter(make_default_params());
+  const auto twist = converter.convert(make_control(-1.0, 0.0));
+  EXPECT_NEAR(twist.linear.x, -0.3, 1e-9);
+}
+
+TEST(ControlToTwistConverter, ZeroWheelBaseGivesZeroAngular)
+{
+  // Defensive: wheel_base = 0 must not divide by zero.
+  ControlToTwistParams p;
+  p.wheel_base = 0.0;
+  p.max_linear_velocity = 0.3;
+  p.max_angular_velocity = 1.57;
+  ControlToTwistConverter converter(p);
+  const auto twist = converter.convert(make_control(0.2, 0.5));
+  EXPECT_DOUBLE_EQ(twist.angular.z, 0.0);
+}
+
+TEST(ControlToTwistConverter, ZeroVelocityZeroSteerYieldsZeroTwist)
+{
+  ControlToTwistConverter converter(make_default_params());
+  const auto twist = converter.convert(make_control(0.0, 0.0));
+  EXPECT_DOUBLE_EQ(twist.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(twist.angular.z, 0.0);
+}

--- a/ros2/kachaka_autoware_vehicle_interface/test/test_control_to_twist_converter.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/test/test_control_to_twist_converter.cpp
@@ -108,3 +108,25 @@ TEST(ControlToTwistConverter, ZeroVelocityZeroSteerYieldsZeroTwist)
   EXPECT_DOUBLE_EQ(twist.linear.x, 0.0);
   EXPECT_DOUBLE_EQ(twist.angular.z, 0.0);
 }
+
+TEST(ControlToTwistConverter, LinearSaturationPreservesCurvature)
+{
+  // Requested v = 1.0 m/s gets clamped to 0.3, but the steering angle is
+  // small enough that omega remains well within saturation. The resulting
+  // (v_clamped, omega) pair must still describe the same curvature
+  // tan(delta)/L the controller asked for; i.e. omega = v_clamped * tan(delta) / L,
+  // not v_unclamped * tan(delta) / L. Computing omega from the unclamped v
+  // (the previous behavior) would over-rotate by the saturation ratio
+  // 1.0/0.3 ≈ 3.3x.
+  ControlToTwistConverter converter(make_default_params());
+  const double delta = 0.1;
+  const auto twist = converter.convert(make_control(1.0, delta));
+
+  const double delta_f = static_cast<double>(static_cast<float>(delta));
+  const double expected_omega = 0.3 * std::tan(delta_f) / 0.30;
+  EXPECT_NEAR(twist.linear.x, 0.3, 1e-9);
+  EXPECT_NEAR(twist.angular.z, expected_omega, 1e-6);
+  // Sanity check against the would-be buggy value.
+  const double buggy_omega = 1.0 * std::tan(delta_f) / 0.30;
+  EXPECT_LT(std::abs(twist.angular.z), std::abs(buggy_omega));
+}

--- a/ros2/kachaka_autoware_vehicle_interface/test/test_operation_mode_state_machine.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/test/test_operation_mode_state_machine.cpp
@@ -14,6 +14,11 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
 #include "kachaka_autoware_vehicle_interface/operation_mode_state_machine.hpp"
 
 using kachaka_autoware_vehicle_interface::OperationMode;
@@ -48,4 +53,53 @@ TEST(OperationModeStateMachine, RequestSameStateIsIdempotent)
   sm.request_autonomous();
   EXPECT_TRUE(sm.request_autonomous());
   EXPECT_EQ(sm.get_state(), OperationMode::AUTONOMOUS);
+}
+
+TEST(OperationModeStateMachine, ConcurrentReadersAndWritersConverge)
+{
+  // Stress the lock: two writer threads alternately request AUTONOMOUS / STOP
+  // while two reader threads continuously sample get_state(). After joining,
+  // the final state must be one of the two valid enum values (i.e. no torn
+  // read or undefined state). Without the internal mutex, TSan / ASan builds
+  // would flag the data race on state_; this test additionally guards against
+  // accidentally removing the lock in the future.
+  OperationModeStateMachine sm;
+  std::atomic<bool> stop{false};
+  std::atomic<int> observed_invalid{0};
+
+  std::vector<std::thread> threads;
+  threads.emplace_back(
+    [&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        sm.request_autonomous();
+      }
+    });
+  threads.emplace_back(
+    [&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        sm.request_stop();
+      }
+    });
+  for (int i = 0; i < 2; ++i) {
+    threads.emplace_back(
+      [&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+          const auto s = sm.get_state();
+          if (s != OperationMode::STOP && s != OperationMode::AUTONOMOUS) {
+            observed_invalid.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+      });
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  stop.store(true, std::memory_order_relaxed);
+  for (auto & t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(observed_invalid.load(), 0);
+  const auto final_state = sm.get_state();
+  EXPECT_TRUE(
+    final_state == OperationMode::STOP || final_state == OperationMode::AUTONOMOUS);
 }

--- a/ros2/kachaka_autoware_vehicle_interface/test/test_operation_mode_state_machine.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/test/test_operation_mode_state_machine.cpp
@@ -1,0 +1,51 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "kachaka_autoware_vehicle_interface/operation_mode_state_machine.hpp"
+
+using kachaka_autoware_vehicle_interface::OperationMode;
+using kachaka_autoware_vehicle_interface::OperationModeStateMachine;
+
+TEST(OperationModeStateMachine, InitialStateIsStop)
+{
+  OperationModeStateMachine sm;
+  EXPECT_EQ(sm.get_state(), OperationMode::STOP);
+}
+
+TEST(OperationModeStateMachine, RequestAutonomousFromStopSucceeds)
+{
+  OperationModeStateMachine sm;
+  EXPECT_TRUE(sm.request_autonomous());
+  EXPECT_EQ(sm.get_state(), OperationMode::AUTONOMOUS);
+}
+
+TEST(OperationModeStateMachine, RequestStopFromAutonomousSucceeds)
+{
+  OperationModeStateMachine sm;
+  sm.request_autonomous();
+  EXPECT_TRUE(sm.request_stop());
+  EXPECT_EQ(sm.get_state(), OperationMode::STOP);
+}
+
+TEST(OperationModeStateMachine, RequestSameStateIsIdempotent)
+{
+  OperationModeStateMachine sm;
+  EXPECT_TRUE(sm.request_stop());
+  EXPECT_EQ(sm.get_state(), OperationMode::STOP);
+  sm.request_autonomous();
+  EXPECT_TRUE(sm.request_autonomous());
+  EXPECT_EQ(sm.get_state(), OperationMode::AUTONOMOUS);
+}

--- a/ros2/kachaka_autoware_vehicle_interface/test/test_velocity_status_publisher.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/test/test_velocity_status_publisher.cpp
@@ -1,0 +1,63 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <nav_msgs/msg/odometry.hpp>
+
+#include "kachaka_autoware_vehicle_interface/velocity_status_publisher.hpp"
+
+using kachaka_autoware_vehicle_interface::convert_odometry_to_velocity_report;
+
+TEST(VelocityStatusPublisher, ConvertsLinearAndAngularComponents)
+{
+  nav_msgs::msg::Odometry odom;
+  odom.header.stamp.sec = 42;
+  odom.header.stamp.nanosec = 123;
+  odom.header.frame_id = "odom";
+  odom.twist.twist.linear.x = 0.15;
+  odom.twist.twist.angular.z = -0.5;
+
+  const auto report = convert_odometry_to_velocity_report(odom);
+  EXPECT_EQ(report.header.stamp.sec, 42);
+  EXPECT_EQ(report.header.stamp.nanosec, 123u);
+  EXPECT_EQ(report.header.frame_id, "odom");
+  EXPECT_FLOAT_EQ(report.longitudinal_velocity, 0.15f);
+  EXPECT_FLOAT_EQ(report.lateral_velocity, 0.0f);
+  EXPECT_FLOAT_EQ(report.heading_rate, -0.5f);
+}
+
+TEST(VelocityStatusPublisher, IgnoresLateralLinearVelocity)
+{
+  // Even if the source odometry carries a non-zero linear.y (which would be
+  // physically meaningless for a differential-drive base), the converter must
+  // emit lateral_velocity = 0.
+  nav_msgs::msg::Odometry odom;
+  odom.twist.twist.linear.x = 0.1;
+  odom.twist.twist.linear.y = 99.0;
+  odom.twist.twist.angular.z = 0.0;
+
+  const auto report = convert_odometry_to_velocity_report(odom);
+  EXPECT_FLOAT_EQ(report.longitudinal_velocity, 0.1f);
+  EXPECT_FLOAT_EQ(report.lateral_velocity, 0.0f);
+}
+
+TEST(VelocityStatusPublisher, ZeroOdometryYieldsZeroReport)
+{
+  nav_msgs::msg::Odometry odom;
+  const auto report = convert_odometry_to_velocity_report(odom);
+  EXPECT_FLOAT_EQ(report.longitudinal_velocity, 0.0f);
+  EXPECT_FLOAT_EQ(report.lateral_velocity, 0.0f);
+  EXPECT_FLOAT_EQ(report.heading_rate, 0.0f);
+}

--- a/ros2/kachaka_autoware_vehicle_interface/test/test_velocity_status_publisher.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/test/test_velocity_status_publisher.cpp
@@ -26,16 +26,32 @@ TEST(VelocityStatusPublisher, ConvertsLinearAndAngularComponents)
   odom.header.stamp.sec = 42;
   odom.header.stamp.nanosec = 123;
   odom.header.frame_id = "odom";
+  odom.child_frame_id = "base_link";
   odom.twist.twist.linear.x = 0.15;
   odom.twist.twist.angular.z = -0.5;
 
   const auto report = convert_odometry_to_velocity_report(odom);
   EXPECT_EQ(report.header.stamp.sec, 42);
   EXPECT_EQ(report.header.stamp.nanosec, 123u);
-  EXPECT_EQ(report.header.frame_id, "odom");
+  // VelocityReport must use the body frame the twist is expressed in, not
+  // the pose's reference frame.
+  EXPECT_EQ(report.header.frame_id, "base_link");
   EXPECT_FLOAT_EQ(report.longitudinal_velocity, 0.15f);
   EXPECT_FLOAT_EQ(report.lateral_velocity, 0.0f);
   EXPECT_FLOAT_EQ(report.heading_rate, -0.5f);
+}
+
+TEST(VelocityStatusPublisher, FrameIdComesFromChildFrameNotPoseFrame)
+{
+  // Regression guard: nav_msgs/Odometry.twist is defined in child_frame_id.
+  // Using header.frame_id here would mis-label body-frame velocities as the
+  // world frame whenever the source odometry is in odom/map.
+  nav_msgs::msg::Odometry odom;
+  odom.header.frame_id = "odom";
+  odom.child_frame_id = "base_link";
+  const auto report = convert_odometry_to_velocity_report(odom);
+  EXPECT_NE(report.header.frame_id, "odom");
+  EXPECT_EQ(report.header.frame_id, "base_link");
 }
 
 TEST(VelocityStatusPublisher, IgnoresLateralLinearVelocity)


### PR DESCRIPTION
## Summary

Stack #2 on top of #4. Adds the `kachaka_autoware_vehicle_interface` package containing three ROS-agnostic conversion modules — the heart of the Autoware Core ↔ Kachaka bridge — each fully unit-tested with gtest.

| Module | Purpose | Tests |
|--------|---------|-------|
| `ControlToTwistConverter` | Ackermann-bicycle → differential-drive twist with linear/angular saturation | 7 |
| `OperationModeStateMachine` | Thread-safe STOP/AUTONOMOUS state, idempotent transitions | 4 |
| `convert_odometry_to_velocity_report` | nav_msgs/Odometry → autoware_vehicle_msgs/VelocityReport (lateral pinned to 0) | 3 |

The rclcpp `VehicleInterfaceNode` that wires these into ROS subscribers/publishers/services arrives in the next stacked PR.

## Test plan

- [x] `colcon build --packages-select kachaka_autoware_vehicle_interface` on Jazzy → build succeeds, no warnings.
- [x] `colcon test --packages-select kachaka_autoware_vehicle_interface` → **14 gtest cases pass**, all linters (cpplint, cppcheck, uncrustify, copyright, lint_cmake, xmllint) pass.
- [x] Code follows Autoware C++ style (double-underscore header guards, copyright headers, include ordering).

## Stack

Based on #4. After #4 merges this rebases onto main automatically.