### PR TITLE
feat(vehicle_interface): add VehicleInterfaceNode with full I/O wiring

### DIFF
--- a/ros2/kachaka_autoware_vehicle_interface/CMakeLists.txt
+++ b/ros2/kachaka_autoware_vehicle_interface/CMakeLists.txt
@@ -17,7 +17,13 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/control_to_twist_converter.cpp
   src/operation_mode_state_machine.cpp
   src/velocity_status_publisher.cpp
+  src/vehicle_interface_node.cpp
 )
+
+ament_auto_add_executable(${PROJECT_NAME}_node
+  src/main.cpp
+)
+target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -38,6 +44,12 @@ if(BUILD_TESTING)
     test/test_velocity_status_publisher.cpp
   )
   target_link_libraries(test_velocity_status_publisher ${PROJECT_NAME})
+
+  ament_add_gtest(test_vehicle_interface_node
+    test/test_vehicle_interface_node.cpp
+    TIMEOUT 30
+  )
+  target_link_libraries(test_vehicle_interface_node ${PROJECT_NAME})
 endif()
 
-ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR INSTALL_TO_SHARE launch config)

--- a/ros2/kachaka_autoware_vehicle_interface/config/vehicle_interface.param.yaml
+++ b/ros2/kachaka_autoware_vehicle_interface/config/vehicle_interface.param.yaml
@@ -1,0 +1,9 @@
+/**:
+  ros__parameters:
+    wheel_base: 0.30
+    max_linear_velocity: 0.3
+    max_angular_velocity: 1.57
+    cmd_vel_timeout: 0.5
+    publish_period_velocity_status: 0.02
+    publish_period_operation_mode: 0.1
+    auto_enable_manual_control: true

--- a/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/vehicle_interface_node.hpp
+++ b/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/vehicle_interface_node.hpp
@@ -1,0 +1,81 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KACHAKA_AUTOWARE_VEHICLE_INTERFACE__VEHICLE_INTERFACE_NODE_HPP_
+#define KACHAKA_AUTOWARE_VEHICLE_INTERFACE__VEHICLE_INTERFACE_NODE_HPP_
+
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+
+#include "kachaka_autoware_vehicle_interface/control_to_twist_converter.hpp"
+#include "kachaka_autoware_vehicle_interface/operation_mode_state_machine.hpp"
+#include "kachaka_autoware_vehicle_interface/velocity_status_publisher.hpp"
+
+namespace kachaka_autoware_vehicle_interface
+{
+
+class VehicleInterfaceNode : public rclcpp::Node
+{
+public:
+  explicit VehicleInterfaceNode(const rclcpp::NodeOptions & options);
+
+private:
+  std::unique_ptr<ControlToTwistConverter> converter_;
+  OperationModeStateMachine state_machine_;
+
+  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr control_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::VelocityReport>::SharedPtr velocity_status_pub_;
+  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::OperationModeState>::SharedPtr op_mode_pub_;
+  rclcpp::Service<autoware_adapi_v1_msgs::srv::ChangeOperationMode>::SharedPtr
+    change_to_autonomous_srv_;
+  rclcpp::Service<autoware_adapi_v1_msgs::srv::ChangeOperationMode>::SharedPtr change_to_stop_srv_;
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr enable_manual_control_client_;
+
+  rclcpp::TimerBase::SharedPtr velocity_status_timer_;
+  rclcpp::TimerBase::SharedPtr op_mode_timer_;
+  rclcpp::TimerBase::SharedPtr cmd_vel_timeout_timer_;
+
+  nav_msgs::msg::Odometry::SharedPtr latest_odom_;
+  rclcpp::Time last_control_stamp_;
+  double cmd_vel_timeout_sec_;
+
+  void on_control(const autoware_control_msgs::msg::Control::SharedPtr msg);
+  void on_odom(const nav_msgs::msg::Odometry::SharedPtr msg);
+  void on_velocity_status_timer();
+  void on_op_mode_timer();
+  void on_cmd_vel_timeout_timer();
+  void on_change_to_autonomous(
+    const autoware_adapi_v1_msgs::srv::ChangeOperationMode::Request::SharedPtr req,
+    autoware_adapi_v1_msgs::srv::ChangeOperationMode::Response::SharedPtr resp);
+  void on_change_to_stop(
+    const autoware_adapi_v1_msgs::srv::ChangeOperationMode::Request::SharedPtr req,
+    autoware_adapi_v1_msgs::srv::ChangeOperationMode::Response::SharedPtr resp);
+
+  void enable_manual_control(bool enable);
+};
+
+}  // namespace kachaka_autoware_vehicle_interface
+
+#endif  // KACHAKA_AUTOWARE_VEHICLE_INTERFACE__VEHICLE_INTERFACE_NODE_HPP_

--- a/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/vehicle_interface_node.hpp
+++ b/ros2/kachaka_autoware_vehicle_interface/include/kachaka_autoware_vehicle_interface/vehicle_interface_node.hpp
@@ -56,10 +56,12 @@ private:
   rclcpp::TimerBase::SharedPtr velocity_status_timer_;
   rclcpp::TimerBase::SharedPtr op_mode_timer_;
   rclcpp::TimerBase::SharedPtr cmd_vel_timeout_timer_;
+  rclcpp::TimerBase::SharedPtr enable_manual_control_timer_;
 
   nav_msgs::msg::Odometry::SharedPtr latest_odom_;
   rclcpp::Time last_control_stamp_;
   double cmd_vel_timeout_sec_;
+  bool enable_manual_control_pending_value_{false};
 
   void on_control(const autoware_control_msgs::msg::Control::SharedPtr msg);
   void on_odom(const nav_msgs::msg::Odometry::SharedPtr msg);

--- a/ros2/kachaka_autoware_vehicle_interface/launch/vehicle_interface.launch.xml
+++ b/ros2/kachaka_autoware_vehicle_interface/launch/vehicle_interface.launch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="config_file"
+       default="$(find-pkg-share kachaka_autoware_vehicle_interface)/config/vehicle_interface.param.yaml"/>
+
+  <node pkg="kachaka_autoware_vehicle_interface"
+        exec="kachaka_autoware_vehicle_interface_node"
+        name="kachaka_autoware_vehicle_interface"
+        output="screen">
+    <param from="$(var config_file)"/>
+  </node>
+</launch>

--- a/ros2/kachaka_autoware_vehicle_interface/package.xml
+++ b/ros2/kachaka_autoware_vehicle_interface/package.xml
@@ -3,17 +3,21 @@
 <package format="3">
   <name>kachaka_autoware_vehicle_interface</name>
   <version>0.0.0</version>
-  <description>Pure-logic libraries used by the Kachaka Autoware vehicle interface: Ackermann-to-differential-drive twist conversion, operation-mode state machine, and odometry-to-VelocityReport conversion. The rclcpp Node that wires these into ROS I/O is added by a follow-up PR.</description>
+  <description>Vehicle Interface bridging Autoware Core control output to Kachaka manual_control/cmd_vel, with operation_mode state machine and velocity_status republishing.</description>
   <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
   <author email="yutaka.kondo@youtalk.jp">Yutaka Kondo</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>std_srvs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/ros2/kachaka_autoware_vehicle_interface/src/main.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/src/main.cpp
@@ -1,0 +1,30 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "kachaka_autoware_vehicle_interface/vehicle_interface_node.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  auto node =
+    std::make_shared<kachaka_autoware_vehicle_interface::VehicleInterfaceNode>(options);
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ros2/kachaka_autoware_vehicle_interface/src/vehicle_interface_node.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/src/vehicle_interface_node.cpp
@@ -1,0 +1,180 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kachaka_autoware_vehicle_interface/vehicle_interface_node.hpp"
+
+#include <chrono>
+#include <memory>
+#include <utility>
+
+namespace kachaka_autoware_vehicle_interface
+{
+
+using namespace std::chrono_literals;
+using OperationModeStateMsg = autoware_adapi_v1_msgs::msg::OperationModeState;
+
+VehicleInterfaceNode::VehicleInterfaceNode(const rclcpp::NodeOptions & options)
+: rclcpp::Node("kachaka_autoware_vehicle_interface", options),
+  last_control_stamp_(0, 0, RCL_ROS_TIME)
+{
+  ControlToTwistParams params;
+  params.wheel_base = declare_parameter<double>("wheel_base", 0.30);
+  params.max_linear_velocity = declare_parameter<double>("max_linear_velocity", 0.3);
+  params.max_angular_velocity = declare_parameter<double>("max_angular_velocity", 1.57);
+  cmd_vel_timeout_sec_ = declare_parameter<double>("cmd_vel_timeout", 0.5);
+  const double velocity_status_period =
+    declare_parameter<double>("publish_period_velocity_status", 0.02);
+  const double op_mode_period =
+    declare_parameter<double>("publish_period_operation_mode", 0.1);
+  const bool auto_enable = declare_parameter<bool>("auto_enable_manual_control", true);
+  converter_ = std::make_unique<ControlToTwistConverter>(params);
+
+  control_sub_ = create_subscription<autoware_control_msgs::msg::Control>(
+    "/control/command/control_cmd", rclcpp::QoS(1),
+    std::bind(&VehicleInterfaceNode::on_control, this, std::placeholders::_1));
+  odom_sub_ = create_subscription<nav_msgs::msg::Odometry>(
+    "/kachaka/wheel_odometry/wheel_odometry", rclcpp::SensorDataQoS(),
+    std::bind(&VehicleInterfaceNode::on_odom, this, std::placeholders::_1));
+
+  twist_pub_ = create_publisher<geometry_msgs::msg::Twist>(
+    "/kachaka/manual_control/cmd_vel", rclcpp::SensorDataQoS());
+  velocity_status_pub_ = create_publisher<autoware_vehicle_msgs::msg::VelocityReport>(
+    "/vehicle/status/velocity_status", rclcpp::QoS(1));
+  op_mode_pub_ = create_publisher<OperationModeStateMsg>(
+    "/system/operation_mode/state", rclcpp::QoS(1).transient_local());
+
+  change_to_autonomous_srv_ =
+    create_service<autoware_adapi_v1_msgs::srv::ChangeOperationMode>(
+    "/system/operation_mode/change_to_autonomous",
+    std::bind(
+      &VehicleInterfaceNode::on_change_to_autonomous, this,
+      std::placeholders::_1, std::placeholders::_2));
+  change_to_stop_srv_ =
+    create_service<autoware_adapi_v1_msgs::srv::ChangeOperationMode>(
+    "/system/operation_mode/change_to_stop",
+    std::bind(
+      &VehicleInterfaceNode::on_change_to_stop, this,
+      std::placeholders::_1, std::placeholders::_2));
+
+  enable_manual_control_client_ =
+    create_client<std_srvs::srv::SetBool>("/kachaka/manual_control/set_enabled");
+
+  velocity_status_timer_ = create_wall_timer(
+    std::chrono::duration<double>(velocity_status_period),
+    std::bind(&VehicleInterfaceNode::on_velocity_status_timer, this));
+  op_mode_timer_ = create_wall_timer(
+    std::chrono::duration<double>(op_mode_period),
+    std::bind(&VehicleInterfaceNode::on_op_mode_timer, this));
+  cmd_vel_timeout_timer_ = create_wall_timer(
+    100ms, std::bind(&VehicleInterfaceNode::on_cmd_vel_timeout_timer, this));
+
+  if (auto_enable) {
+    enable_manual_control(true);
+  }
+
+  RCLCPP_INFO(
+    get_logger(),
+    "VehicleInterfaceNode started: wheel_base=%.3f, vmax=%.3f, wmax=%.3f, timeout=%.2fs",
+    params.wheel_base, params.max_linear_velocity, params.max_angular_velocity,
+    cmd_vel_timeout_sec_);
+}
+
+void VehicleInterfaceNode::on_control(
+  const autoware_control_msgs::msg::Control::SharedPtr msg)
+{
+  last_control_stamp_ = now();
+  if (state_machine_.get_state() != OperationMode::AUTONOMOUS) {
+    return;
+  }
+  twist_pub_->publish(converter_->convert(*msg));
+}
+
+void VehicleInterfaceNode::on_odom(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+  latest_odom_ = msg;
+}
+
+void VehicleInterfaceNode::on_velocity_status_timer()
+{
+  if (!latest_odom_) {
+    return;
+  }
+  velocity_status_pub_->publish(convert_odometry_to_velocity_report(*latest_odom_));
+}
+
+void VehicleInterfaceNode::on_op_mode_timer()
+{
+  OperationModeStateMsg state;
+  state.stamp = now();
+  state.mode = (state_machine_.get_state() == OperationMode::AUTONOMOUS) ?
+    OperationModeStateMsg::AUTONOMOUS :
+    OperationModeStateMsg::STOP;
+  state.is_autoware_control_enabled = (state.mode == OperationModeStateMsg::AUTONOMOUS);
+  state.is_in_transition = false;
+  state.is_stop_mode_available = true;
+  state.is_autonomous_mode_available = true;
+  state.is_local_mode_available = false;
+  state.is_remote_mode_available = false;
+  op_mode_pub_->publish(state);
+}
+
+void VehicleInterfaceNode::on_cmd_vel_timeout_timer()
+{
+  if (state_machine_.get_state() != OperationMode::AUTONOMOUS) {
+    return;
+  }
+  // Skip until the first control message has arrived (last_control_stamp_ == 0).
+  if (last_control_stamp_.nanoseconds() == 0) {
+    return;
+  }
+  const auto elapsed = (now() - last_control_stamp_).seconds();
+  if (elapsed > cmd_vel_timeout_sec_) {
+    geometry_msgs::msg::Twist zero;
+    twist_pub_->publish(zero);
+  }
+}
+
+void VehicleInterfaceNode::on_change_to_autonomous(
+  const autoware_adapi_v1_msgs::srv::ChangeOperationMode::Request::SharedPtr /*req*/,
+  autoware_adapi_v1_msgs::srv::ChangeOperationMode::Response::SharedPtr resp)
+{
+  state_machine_.request_autonomous();
+  resp->status.success = true;
+}
+
+void VehicleInterfaceNode::on_change_to_stop(
+  const autoware_adapi_v1_msgs::srv::ChangeOperationMode::Request::SharedPtr /*req*/,
+  autoware_adapi_v1_msgs::srv::ChangeOperationMode::Response::SharedPtr resp)
+{
+  state_machine_.request_stop();
+  resp->status.success = true;
+}
+
+void VehicleInterfaceNode::enable_manual_control(bool enable)
+{
+  if (!enable_manual_control_client_->wait_for_service(2s)) {
+    RCLCPP_WARN(
+      get_logger(),
+      "/kachaka/manual_control/set_enabled service not available; manual_control will be enabled "
+      "lazily on the first cmd_vel.");
+    return;
+  }
+  auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
+  req->data = enable;
+  enable_manual_control_client_->async_send_request(req);
+  RCLCPP_INFO(
+    get_logger(), "Requested set_manual_control_enabled(%s)", enable ? "true" : "false");
+}
+
+}  // namespace kachaka_autoware_vehicle_interface

--- a/ros2/kachaka_autoware_vehicle_interface/src/vehicle_interface_node.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/src/vehicle_interface_node.cpp
@@ -93,10 +93,14 @@ VehicleInterfaceNode::VehicleInterfaceNode(const rclcpp::NodeOptions & options)
 void VehicleInterfaceNode::on_control(
   const autoware_control_msgs::msg::Control::SharedPtr msg)
 {
-  last_control_stamp_ = now();
+  // Only stamp on AUTONOMOUS-period traffic — the watchdog is "control_cmd
+  // stops arriving while AUTONOMOUS". Stamping unconditionally would let
+  // STOP-mode chatter reset the watchdog and silently delay the zero-Twist
+  // failsafe by up to cmd_vel_timeout after the AUTONOMOUS transition.
   if (state_machine_.get_state() != OperationMode::AUTONOMOUS) {
     return;
   }
+  last_control_stamp_ = now();
   twist_pub_->publish(converter_->convert(*msg));
 }
 
@@ -149,6 +153,10 @@ void VehicleInterfaceNode::on_change_to_autonomous(
   const autoware_adapi_v1_msgs::srv::ChangeOperationMode::Request::SharedPtr /*req*/,
   autoware_adapi_v1_msgs::srv::ChangeOperationMode::Response::SharedPtr resp)
 {
+  // Reset the watchdog stamp so a stale timestamp from a prior AUTONOMOUS
+  // session cannot trip the zero-Twist failsafe before the first new
+  // control_cmd is received.
+  last_control_stamp_ = rclcpp::Time(0, 0, RCL_ROS_TIME);
   state_machine_.request_autonomous();
   resp->status.success = true;
 }
@@ -163,18 +171,25 @@ void VehicleInterfaceNode::on_change_to_stop(
 
 void VehicleInterfaceNode::enable_manual_control(bool enable)
 {
-  if (!enable_manual_control_client_->wait_for_service(2s)) {
-    RCLCPP_WARN(
-      get_logger(),
-      "/kachaka/manual_control/set_enabled service not available; manual_control will be enabled "
-      "lazily on the first cmd_vel.");
-    return;
-  }
-  auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
-  req->data = enable;
-  enable_manual_control_client_->async_send_request(req);
-  RCLCPP_INFO(
-    get_logger(), "Requested set_manual_control_enabled(%s)", enable ? "true" : "false");
+  // Non-blocking: arm a 500 ms periodic timer that polls service availability
+  // and fires the request once the service shows up. Avoids stalling the node
+  // constructor for up to 2 s when the Kachaka bridge is not (yet) running.
+  // The bridge's manual_control component additionally has a lazy-enable
+  // fallback on the first cmd_vel, so a missing service here is non-fatal.
+  enable_manual_control_pending_value_ = enable;
+  enable_manual_control_timer_ = create_wall_timer(
+    500ms, [this]() {
+      if (!enable_manual_control_client_->service_is_ready()) {
+        return;
+      }
+      auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
+      req->data = enable_manual_control_pending_value_;
+      enable_manual_control_client_->async_send_request(req);
+      RCLCPP_INFO(
+        get_logger(), "Requested set_manual_control_enabled(%s)",
+        enable_manual_control_pending_value_ ? "true" : "false");
+      enable_manual_control_timer_->cancel();
+    });
 }
 
 }  // namespace kachaka_autoware_vehicle_interface

--- a/ros2/kachaka_autoware_vehicle_interface/test/test_vehicle_interface_node.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/test/test_vehicle_interface_node.cpp
@@ -1,0 +1,255 @@
+// Copyright 2026 Yutaka Kondo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include "kachaka_autoware_vehicle_interface/vehicle_interface_node.hpp"
+
+using namespace std::chrono_literals;
+using kachaka_autoware_vehicle_interface::VehicleInterfaceNode;
+using ChangeOperationMode = autoware_adapi_v1_msgs::srv::ChangeOperationMode;
+using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
+
+namespace
+{
+
+// Spin both the node-under-test and the helper node together until `predicate`
+// becomes true or the deadline elapses. Returns true when the predicate fired.
+template<typename Predicate>
+bool spin_until(
+  rclcpp::Executor & executor, std::chrono::milliseconds timeout, Predicate predicate)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    executor.spin_some();
+    if (predicate()) {
+      return true;
+    }
+    std::this_thread::sleep_for(5ms);
+  }
+  executor.spin_some();
+  return predicate();
+}
+
+class VehicleInterfaceNodeFixture : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::NodeOptions options;
+    options.append_parameter_override("auto_enable_manual_control", false);
+    options.append_parameter_override("publish_period_velocity_status", 0.02);
+    options.append_parameter_override("publish_period_operation_mode", 0.05);
+    options.append_parameter_override("cmd_vel_timeout", 0.2);
+    node_ = std::make_shared<VehicleInterfaceNode>(options);
+    helper_ = std::make_shared<rclcpp::Node>("vehicle_interface_test_helper");
+
+    control_pub_ = helper_->create_publisher<autoware_control_msgs::msg::Control>(
+      "/control/command/control_cmd", rclcpp::QoS(1));
+    odom_pub_ = helper_->create_publisher<nav_msgs::msg::Odometry>(
+      "/kachaka/wheel_odometry/wheel_odometry", rclcpp::SensorDataQoS());
+    twist_sub_ = helper_->create_subscription<geometry_msgs::msg::Twist>(
+      "/kachaka/manual_control/cmd_vel", rclcpp::SensorDataQoS(),
+      [this](const geometry_msgs::msg::Twist::SharedPtr msg) {last_twist_ = *msg;});
+    velocity_status_sub_ =
+      helper_->create_subscription<autoware_vehicle_msgs::msg::VelocityReport>(
+      "/vehicle/status/velocity_status", rclcpp::QoS(1),
+      [this](const autoware_vehicle_msgs::msg::VelocityReport::SharedPtr msg) {
+        last_velocity_status_ = *msg;
+      });
+    op_mode_sub_ =
+      helper_->create_subscription<OperationModeState>(
+      "/system/operation_mode/state", rclcpp::QoS(1).transient_local(),
+      [this](const OperationModeState::SharedPtr msg) {last_op_mode_ = *msg;});
+    change_to_autonomous_client_ =
+      helper_->create_client<ChangeOperationMode>(
+      "/system/operation_mode/change_to_autonomous");
+    change_to_stop_client_ =
+      helper_->create_client<ChangeOperationMode>(
+      "/system/operation_mode/change_to_stop");
+
+    executor_.add_node(node_);
+    executor_.add_node(helper_);
+  }
+
+  void TearDown() override
+  {
+    executor_.remove_node(helper_);
+    executor_.remove_node(node_);
+  }
+
+  bool change_mode(rclcpp::Client<ChangeOperationMode>::SharedPtr client)
+  {
+    if (!client->wait_for_service(1s)) {
+      return false;
+    }
+    auto req = std::make_shared<ChangeOperationMode::Request>();
+    auto future = client->async_send_request(req);
+    return spin_until(
+      executor_, 1s, [&future] {
+        return future.wait_for(0s) == std::future_status::ready;
+      });
+  }
+
+  rclcpp::executors::SingleThreadedExecutor executor_;
+  std::shared_ptr<VehicleInterfaceNode> node_;
+  std::shared_ptr<rclcpp::Node> helper_;
+
+  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr control_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::VelocityReport>::SharedPtr
+    velocity_status_sub_;
+  rclcpp::Subscription<OperationModeState>::SharedPtr op_mode_sub_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr change_to_autonomous_client_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr change_to_stop_client_;
+
+  std::optional<geometry_msgs::msg::Twist> last_twist_;
+  std::optional<autoware_vehicle_msgs::msg::VelocityReport> last_velocity_status_;
+  std::optional<OperationModeState> last_op_mode_;
+};
+
+}  // namespace
+
+TEST_F(VehicleInterfaceNodeFixture, OpModeStartsInStop)
+{
+  ASSERT_TRUE(spin_until(executor_, 1s, [this] {return last_op_mode_.has_value();}));
+  EXPECT_EQ(last_op_mode_->mode, OperationModeState::STOP);
+  EXPECT_FALSE(last_op_mode_->is_autoware_control_enabled);
+}
+
+TEST_F(VehicleInterfaceNodeFixture, ControlIsBlockedWhileStop)
+{
+  // Without changing to AUTONOMOUS, publish a control_cmd and confirm no Twist appears.
+  ASSERT_TRUE(spin_until(executor_, 500ms, [this] {return last_op_mode_.has_value();}));
+
+  autoware_control_msgs::msg::Control cmd;
+  cmd.longitudinal.velocity = 0.2f;
+  control_pub_->publish(cmd);
+
+  // Spin briefly, then assert no Twist was received.
+  spin_until(executor_, 200ms, [] {return false;});
+  EXPECT_FALSE(last_twist_.has_value());
+}
+
+TEST_F(VehicleInterfaceNodeFixture, AutonomousGatePassesControlToTwist)
+{
+  ASSERT_TRUE(change_mode(change_to_autonomous_client_));
+  ASSERT_TRUE(
+    spin_until(
+      executor_, 500ms,
+      [this] {return last_op_mode_ && last_op_mode_->mode == OperationModeState::AUTONOMOUS;}));
+
+  autoware_control_msgs::msg::Control cmd;
+  cmd.longitudinal.velocity = 0.15f;
+  cmd.lateral.steering_tire_angle = 0.0f;
+  control_pub_->publish(cmd);
+
+  ASSERT_TRUE(spin_until(executor_, 500ms, [this] {return last_twist_.has_value();}));
+  EXPECT_NEAR(last_twist_->linear.x, 0.15, 1e-5);
+  EXPECT_NEAR(last_twist_->angular.z, 0.0, 1e-5);
+}
+
+TEST_F(VehicleInterfaceNodeFixture, ChangeToStopBlocksFurtherControl)
+{
+  ASSERT_TRUE(change_mode(change_to_autonomous_client_));
+  ASSERT_TRUE(
+    spin_until(
+      executor_, 500ms,
+      [this] {return last_op_mode_ && last_op_mode_->mode == OperationModeState::AUTONOMOUS;}));
+
+  autoware_control_msgs::msg::Control cmd;
+  cmd.longitudinal.velocity = 0.1f;
+  control_pub_->publish(cmd);
+  ASSERT_TRUE(spin_until(executor_, 500ms, [this] {return last_twist_.has_value();}));
+
+  ASSERT_TRUE(change_mode(change_to_stop_client_));
+  ASSERT_TRUE(
+    spin_until(
+      executor_, 500ms,
+      [this] {return last_op_mode_ && last_op_mode_->mode == OperationModeState::STOP;}));
+
+  last_twist_.reset();
+  cmd.longitudinal.velocity = 0.25f;
+  control_pub_->publish(cmd);
+  // Allow up to 2x the cmd_vel_timeout (0.2s) so the timer can fire if it would,
+  // then assert no new Twist was received (timeout zero-Twist is also gated by
+  // the AUTONOMOUS check, so STOP remains silent).
+  spin_until(executor_, 400ms, [] {return false;});
+  EXPECT_FALSE(last_twist_.has_value());
+}
+
+TEST_F(VehicleInterfaceNodeFixture, OdometryRepublishedAsVelocityStatus)
+{
+  nav_msgs::msg::Odometry odom;
+  odom.header.frame_id = "odom";
+  odom.twist.twist.linear.x = 0.123;
+  odom.twist.twist.angular.z = 0.456;
+  odom_pub_->publish(odom);
+
+  ASSERT_TRUE(
+    spin_until(
+      executor_, 500ms, [this] {return last_velocity_status_.has_value();}));
+  EXPECT_FLOAT_EQ(last_velocity_status_->longitudinal_velocity, 0.123f);
+  EXPECT_FLOAT_EQ(last_velocity_status_->lateral_velocity, 0.0f);
+  EXPECT_FLOAT_EQ(last_velocity_status_->heading_rate, 0.456f);
+}
+
+TEST_F(VehicleInterfaceNodeFixture, CmdVelTimeoutPublishesZeroTwist)
+{
+  ASSERT_TRUE(change_mode(change_to_autonomous_client_));
+  ASSERT_TRUE(
+    spin_until(
+      executor_, 500ms,
+      [this] {return last_op_mode_ && last_op_mode_->mode == OperationModeState::AUTONOMOUS;}));
+
+  autoware_control_msgs::msg::Control cmd;
+  cmd.longitudinal.velocity = 0.2f;
+  control_pub_->publish(cmd);
+  ASSERT_TRUE(spin_until(executor_, 500ms, [this] {return last_twist_.has_value();}));
+  EXPECT_NEAR(last_twist_->linear.x, 0.2, 1e-5);
+
+  // Stop publishing control_cmd. After cmd_vel_timeout (0.2s) the watchdog
+  // timer should publish a zero Twist.
+  last_twist_.reset();
+  ASSERT_TRUE(
+    spin_until(
+      executor_, 1500ms, [this] {
+        return last_twist_.has_value() &&
+               std::abs(last_twist_->linear.x) < 1e-9 &&
+               std::abs(last_twist_->angular.z) < 1e-9;
+      }));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/ros2/kachaka_autoware_vehicle_interface/test/test_vehicle_interface_node.cpp
+++ b/ros2/kachaka_autoware_vehicle_interface/test/test_vehicle_interface_node.cpp
@@ -15,8 +15,11 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cmath>
+#include <future>
 #include <memory>
 #include <optional>
+#include <thread>
 
 #include <rclcpp/rclcpp.hpp>
 


### PR DESCRIPTION
## Summary

Stack #3 on top of #5. Composes the three pure-logic modules from the previous PR into a complete rclcpp Node, plus its launch and parameter file.

**Behaviors wired into `VehicleInterfaceNode`:**
- Subscribes \`/control/command/control_cmd\` and forwards a converted Twist to \`/kachaka/manual_control/cmd_vel\` only while AUTONOMOUS.
- Subscribes Kachaka \`/kachaka/wheel_odometry/wheel_odometry\` and republishes as \`/vehicle/status/velocity_status\` at 50 Hz.
- Publishes \`/system/operation_mode/state\` at 10 Hz with transient_local QoS.
- Hosts \`/system/operation_mode/change_to_{autonomous,stop}\` services (\`autoware_adapi_v1_msgs/srv/ChangeOperationMode\`).
- Async-calls \`/kachaka/manual_control/set_enabled\` at startup (configurable; the bridge's manual_control component also has a lazy fallback on first cmd_vel).
- Watchdog timer publishes a zero Twist when \`control_cmd\` stops arriving for \`cmd_vel_timeout\` seconds while AUTONOMOUS.

## Test plan

- [x] **6 integration tests** with a \`SingleThreadedExecutor\` driving the real node + helper node. All pass on Jazzy:
  - \`OpModeStartsInStop\` — initial mode is STOP, autoware control disabled.
  - \`ControlIsBlockedWhileStop\` — control_cmd in STOP yields no Twist.
  - \`AutonomousGatePassesControlToTwist\` — change_to_autonomous → control_cmd → expected Twist.
  - \`ChangeToStopBlocksFurtherControl\` — change_to_stop blocks subsequent control_cmd.
  - \`OdometryRepublishedAsVelocityStatus\` — wheel_odometry → VelocityReport with lateral=0.
  - \`CmdVelTimeoutPublishesZeroTwist\` — silent control_cmd → watchdog zero Twist.
- [x] **14 existing gtest cases** for the pure-logic modules still pass.
- [x] All linters pass (cpplint, cppcheck, uncrustify, copyright, lint_cmake, xmllint).
- [x] \`ros2 launch kachaka_autoware_vehicle_interface vehicle_interface.launch.xml\` boots cleanly without Kachaka (logs a one-time WARN about the manual_control service being absent and falls back to lazy enable).
- [ ] Live integration with a real Kachaka — deferred (Task 29 in the MVP plan).

## Stack

Based on #5. Rebases automatically as the stack lands.