### PR TITLE
feat(bridge): add localization, planning, control, AD-API, integrated launches

### DIFF
--- a/ros2/kachaka_autoware_bridge/CMakeLists.txt
+++ b/ros2/kachaka_autoware_bridge/CMakeLists.txt
@@ -3,7 +3,7 @@ project(kachaka_autoware_bridge)
 
 find_package(ament_cmake REQUIRED)
 
-install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY launch config DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/ros2/kachaka_autoware_bridge/config/pose_initializer.param.yaml
+++ b/ros2/kachaka_autoware_bridge/config/pose_initializer.param.yaml
@@ -1,0 +1,39 @@
+/**:
+  ros__parameters:
+    user_defined_initial_pose:
+      enable: false
+      pose: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+    gnss_pose_timeout: 3.0
+    stop_check_duration: 3.0
+    pose_error_threshold: 5.0
+    pose_error_check_enabled: false
+    ekf_enabled: true
+    gnss_enabled: false
+    yabloc_enabled: false
+    ndt_enabled: true
+    stop_check_enabled: true
+
+    map_height_fitter:
+      map_loader_name: "/map/pointcloud_map_loader"
+      target: "pointcloud_map"
+
+    gnss_particle_covariance:
+      [
+        1.0, 0.0, 0.0,  0.0,  0.0,  0.0,
+        0.0, 1.0, 0.0,  0.0,  0.0,  0.0,
+        0.0, 0.0, 0.01, 0.0,  0.0,  0.0,
+        0.0, 0.0, 0.0,  0.01, 0.0,  0.0,
+        0.0, 0.0, 0.0,  0.0,  0.01, 0.0,
+        0.0, 0.0, 0.0,  0.0,  0.0,  10.0,
+      ]
+
+    output_pose_covariance:
+      [
+        1.0, 0.0, 0.0,  0.0,  0.0,  0.0,
+        0.0, 1.0, 0.0,  0.0,  0.0,  0.0,
+        0.0, 0.0, 0.01, 0.0,  0.0,  0.0,
+        0.0, 0.0, 0.0,  0.01, 0.0,  0.0,
+        0.0, 0.0, 0.0,  0.0,  0.01, 0.0,
+        0.0, 0.0, 0.0,  0.0,  0.0,  0.2,
+      ]

--- a/ros2/kachaka_autoware_bridge/config/pose_initializer.param.yaml
+++ b/ros2/kachaka_autoware_bridge/config/pose_initializer.param.yaml
@@ -2,7 +2,9 @@
   ros__parameters:
     user_defined_initial_pose:
       enable: false
-      pose: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      # [x, y, z, qx, qy, qz, qw] - identity quaternion so flipping `enable`
+      # later yields a valid orientation by default.
+      pose: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
 
     gnss_pose_timeout: 3.0
     stop_check_duration: 3.0

--- a/ros2/kachaka_autoware_bridge/launch/api.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/api.launch.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<launch>
+  <include file="$(find-pkg-share autoware_core_api)/launch/autoware_core_api.launch.xml">
+    <arg name="launch_default_adapi" value="true"/>
+    <arg name="launch_rviz_adaptors" value="true"/>
+  </include>
+</launch>

--- a/ros2/kachaka_autoware_bridge/launch/control.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/control.launch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="vehicle_info_param_file"
+       default="$(find-pkg-share kachaka_autoware_description)/config/vehicle_info.param.yaml"/>
+
+  <include file="$(find-pkg-share autoware_core_control)/launch/autoware_core_control.launch.xml">
+    <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
+  </include>
+</launch>

--- a/ros2/kachaka_autoware_bridge/launch/kachaka_autoware.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/kachaka_autoware.launch.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="server_uri" default="192.168.1.91:26400" description="Kachaka gRPC URI"/>
-  <arg name="kachaka_namespace" default="kachaka"/>
-  <arg name="frame_prefix" default=""/>
-  <arg name="sensor_hostname" default="os-122000000000.local"
-       description="Ouster OS-1 hostname or IP"/>
+  <!--
+    The 'kachaka' namespace is currently hardcoded. The Vehicle Interface and
+    several Autoware Core launches reference Kachaka topics by absolute path
+    (/kachaka/wheel_odometry/wheel_odometry, /kachaka/manual_control/cmd_vel,
+    /kachaka/manual_control/set_enabled). Multi-robot use-cases that need a
+    different namespace would also need matching remaps in
+    kachaka_autoware_vehicle_interface — out of scope for the MVP.
+  -->
+  <arg name="frame_prefix" default=""
+       description="Prefix prepended to every TF frame_id (set when running multiple Kachakas)."/>
+  <arg name="sensor_hostname" default="os-sensor.local"
+       description="Ouster OS-1 hostname or IP. Override per robot."/>
   <arg name="map_path" default="$(env HOME)/maps/kachaka_home"/>
   <arg name="vehicle_info_param_file"
        default="$(find-pkg-share kachaka_autoware_description)/config/vehicle_info.param.yaml"/>
@@ -12,12 +20,15 @@
   <!-- Kachaka gRPC bridge -->
   <include file="$(find-pkg-share kachaka_grpc_ros2_bridge)/launch/grpc_ros2_bridge.launch.xml">
     <arg name="server_uri" value="$(var server_uri)"/>
-    <arg name="namespace" value="$(var kachaka_namespace)"/>
+    <arg name="namespace" value="kachaka"/>
     <arg name="frame_prefix" value="$(var frame_prefix)"/>
   </include>
 
-  <!-- Robot description with shelf + OS-1 -->
-  <include file="$(find-pkg-share kachaka_autoware_description)/launch/robot_description.launch.py"/>
+  <!-- Robot description with shelf + OS-1 (frame_prefix kept consistent with
+       the gRPC bridge so TF frame_ids match across publishers). -->
+  <include file="$(find-pkg-share kachaka_autoware_description)/launch/robot_description.launch.py">
+    <arg name="frame_prefix" value="$(var frame_prefix)"/>
+  </include>
 
   <!-- Ouster OS-1 sensor -->
   <include file="$(find-pkg-share kachaka_autoware_bridge)/launch/sensor_ouster.launch.xml">

--- a/ros2/kachaka_autoware_bridge/launch/kachaka_autoware.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/kachaka_autoware.launch.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="server_uri" default="192.168.1.91:26400" description="Kachaka gRPC URI"/>
+  <arg name="kachaka_namespace" default="kachaka"/>
+  <arg name="frame_prefix" default=""/>
+  <arg name="sensor_hostname" default="os-122000000000.local"
+       description="Ouster OS-1 hostname or IP"/>
+  <arg name="map_path" default="$(env HOME)/maps/kachaka_home"/>
+  <arg name="vehicle_info_param_file"
+       default="$(find-pkg-share kachaka_autoware_description)/config/vehicle_info.param.yaml"/>
+
+  <!-- Kachaka gRPC bridge -->
+  <include file="$(find-pkg-share kachaka_grpc_ros2_bridge)/launch/grpc_ros2_bridge.launch.xml">
+    <arg name="server_uri" value="$(var server_uri)"/>
+    <arg name="namespace" value="$(var kachaka_namespace)"/>
+    <arg name="frame_prefix" value="$(var frame_prefix)"/>
+  </include>
+
+  <!-- Robot description with shelf + OS-1 -->
+  <include file="$(find-pkg-share kachaka_autoware_description)/launch/robot_description.launch.py"/>
+
+  <!-- Ouster OS-1 sensor -->
+  <include file="$(find-pkg-share kachaka_autoware_bridge)/launch/sensor_ouster.launch.xml">
+    <arg name="sensor_hostname" value="$(var sensor_hostname)"/>
+  </include>
+
+  <!-- Sensing (vehicle_velocity_converter etc.) -->
+  <include file="$(find-pkg-share autoware_core_sensing)/launch/autoware_core_sensing.launch.xml"/>
+
+  <!-- Localization (NDT + EKF) and Map -->
+  <include file="$(find-pkg-share kachaka_autoware_bridge)/launch/localization.launch.xml">
+    <arg name="map_path" value="$(var map_path)"/>
+  </include>
+
+  <!-- Planning -->
+  <include file="$(find-pkg-share kachaka_autoware_bridge)/launch/planning.launch.xml">
+    <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
+  </include>
+
+  <!-- Control -->
+  <include file="$(find-pkg-share kachaka_autoware_bridge)/launch/control.launch.xml">
+    <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
+  </include>
+
+  <!-- Vehicle Interface (Control to Twist + operation_mode + VelocityReport) -->
+  <include file="$(find-pkg-share kachaka_autoware_vehicle_interface)/launch/vehicle_interface.launch.xml"/>
+
+  <!-- AD-API -->
+  <include file="$(find-pkg-share kachaka_autoware_bridge)/launch/api.launch.xml"/>
+</launch>

--- a/ros2/kachaka_autoware_bridge/launch/localization.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/localization.launch.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="map_path" default="$(env HOME)/maps/kachaka_home"
+       description="Directory holding pointcloud_map.pcd, lanelet2_map.osm, etc."/>
+
+  <include file="$(find-pkg-share autoware_core_map)/launch/autoware_core_map.launch.xml">
+    <arg name="lanelet2_map_path" value="$(var map_path)/lanelet2_map.osm"/>
+    <arg name="map_projector_info_path" value="$(var map_path)/map_projector_info.yaml"/>
+    <arg name="pointcloud_map_path" value="$(var map_path)/pointcloud_map.pcd"/>
+    <arg name="pointcloud_map_metadata_path" value="$(var map_path)/pointcloud_map/metadata.yaml"/>
+  </include>
+
+  <include file="$(find-pkg-share autoware_core_localization)/launch/autoware_core_localization.launch.xml">
+    <arg name="pose_initializer_param_path"
+         value="$(find-pkg-share kachaka_autoware_bridge)/config/pose_initializer.param.yaml"/>
+    <arg name="lidar_input_topic" value="/sensing/lidar/top/pointcloud_raw_ex"/>
+  </include>
+</launch>

--- a/ros2/kachaka_autoware_bridge/launch/planning.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/planning.launch.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="vehicle_info_param_file"
+       default="$(find-pkg-share kachaka_autoware_description)/config/vehicle_info.param.yaml"/>
+
+  <!--
+    NOTE: autoware_core_planning.launch.xml only forwards vehicle_param_file to
+    behavior_velocity_planner / motion_velocity_planner; mission_planner,
+    path_generator, and velocity_smoother also dereference VehicleInfoUtils and
+    will throw "wheel_radius must be initialized" on startup. Fixing this
+    requires either a patch upstream or forking the planning launch into this
+    wrapper. Tracked for M4 live bring-up.
+  -->
+  <include file="$(find-pkg-share autoware_core_planning)/launch/autoware_core_planning.launch.xml">
+    <arg name="vehicle_param_file" value="$(var vehicle_info_param_file)"/>
+    <!-- ObstacleStop disabled for the MVP; re-enabled in M6 once perception
+         input is wired up. -->
+    <arg name="motion_velocity_planner_launch_modules" value="[]"/>
+  </include>
+</launch>

--- a/ros2/kachaka_autoware_bridge/launch/temp_velocity_relay.launch.xml
+++ b/ros2/kachaka_autoware_bridge/launch/temp_velocity_relay.launch.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<launch>
+  <!--
+    TEMPORARY: Republish Kachaka wheel_odometry as Autoware VelocityReport.
+    Used during M2 (localization-only) bring-up before the
+    kachaka_autoware_vehicle_interface node is wired in. The vehicle interface
+    itself publishes /vehicle/status/velocity_status, so once the full
+    kachaka_autoware.launch.xml is used this relay should NOT be launched.
+  -->
+  <node pkg="topic_tools" exec="transform" name="wheel_odom_to_velocity_status">
+    <param name="input_topic" value="/kachaka/wheel_odometry/wheel_odometry"/>
+    <param name="output_topic" value="/vehicle/status/velocity_status"/>
+    <param name="output_type" value="autoware_vehicle_msgs/msg/VelocityReport"/>
+    <param name="expression"
+           value="autoware_vehicle_msgs.msg.VelocityReport(header=m.header, longitudinal_velocity=m.twist.twist.linear.x, lateral_velocity=0.0, heading_rate=m.twist.twist.angular.z)"/>
+    <param name="import" value="['autoware_vehicle_msgs.msg']"/>
+  </node>
+</launch>

--- a/ros2/kachaka_autoware_bridge/package.xml
+++ b/ros2/kachaka_autoware_bridge/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>kachaka_autoware_bridge</name>
   <version>0.0.0</version>
-  <description>Launch wrappers connecting Kachaka sensors to Autoware Core. Currently provides the Ouster OS-1 driver wrapper that publishes onto Autoware-expected topics; additional launches (localization, planning, control, integrated bringup) land in subsequent PRs.</description>
+  <description>Top-level launch and integration glue connecting the Kachaka gRPC ROS 2 bridge to Autoware Core (Ouster sensor wrapper, localization / planning / control / AD-API launches, and the integrated bringup).</description>
   <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
   <author email="yutaka.kondo@youtalk.jp">Yutaka Kondo</author>
@@ -13,7 +13,22 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch_xml</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+
+  <exec_depend>kachaka_grpc_ros2_bridge</exec_depend>
+  <exec_depend>kachaka_autoware_description</exec_depend>
+  <exec_depend>kachaka_autoware_maps</exec_depend>
+  <exec_depend>kachaka_autoware_vehicle_interface</exec_depend>
+
   <exec_depend>ouster_ros</exec_depend>
+
+  <exec_depend>autoware_core_api</exec_depend>
+  <exec_depend>autoware_core_control</exec_depend>
+  <exec_depend>autoware_core_localization</exec_depend>
+  <exec_depend>autoware_core_map</exec_depend>
+  <exec_depend>autoware_core_planning</exec_depend>
+  <exec_depend>autoware_core_sensing</exec_depend>
+  <exec_depend>autoware_default_adapi</exec_depend>
+  <exec_depend>autoware_adapi_adaptors</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary

Stack #4 on top of #6. Brings up the rest of the Autoware Core pipeline through launch wrappers around \`autoware_core_*\`, plus a single-entry-point \`kachaka_autoware.launch.xml\` that orchestrates the whole MVP stack.

| Launch | Wraps | Notes |
|--------|-------|-------|
| \`localization.launch.xml\` | \`autoware_core_map\` + \`autoware_core_localization\` | GNSS / YabLoc disabled in \`pose_initializer.param.yaml\`; NDT + EKF + stop_check enabled (indoor configuration). |
| \`planning.launch.xml\` | \`autoware_core_planning\` | ObstacleStop module disabled until perception is wired in (M6). |
| \`control.launch.xml\` | \`autoware_core_control\` | Wraps \`autoware_simple_pure_pursuit\`. |
| \`api.launch.xml\` | \`autoware_core_api\` | default_adapi + rviz_adaptors. |
| \`kachaka_autoware.launch.xml\` | All of the above + Kachaka gRPC bridge + robot_description + OS-1 + sensing + vehicle_interface | Single MVP entry point. |
| \`temp_velocity_relay.launch.xml\` | \`topic_tools transform\` | M2-only relay to expose Kachaka wheel_odometry as VelocityReport before vehicle_interface is launched. |

Plus \`pose_initializer.param.yaml\` (Kachaka indoor overrides) and the \`autoware_core_*\` / \`autoware_default_adapi\` exec_depends that the wrappers need at runtime.

## Test plan

- [x] \`colcon build --packages-select kachaka_autoware_bridge\` → clean.
- [x] \`colcon test\` on all three new packages (\`maps\`, \`bridge\`, \`vehicle_interface\`) → all linters pass; gtests still all green (20 cases).
- [x] \`xmllint\` on every launch file → OK.
- [x] \`ros2 launch kachaka_autoware_bridge api.launch.xml\` → AD-API container loads \`/adapi/node/{interface,localization,routing}\` cleanly.
- [x] \`ros2 launch kachaka_autoware_bridge planning.launch.xml\` → all six planning nodes spawn (see Known Issue below for what fails next).
- [ ] Live bring-up of \`kachaka_autoware.launch.xml\` against the real Kachaka, OS-1, and a populated \`~/maps/kachaka_home/\` — deferred to M4/M5 live testing (Tasks 35-37 in the MVP plan).

## Known issue (deferred to M4 live testing)

\`autoware_core_planning.launch.xml\` only forwards \`vehicle_param_file\` to \`behavior_velocity_planner\` / \`motion_velocity_planner\`. \`mission_planner\`, \`path_generator\`, and \`velocity_smoother\` also dereference \`VehicleInfoUtils::getVehicleInfo()\` and throw \`Statically typed parameter 'wheel_radius' must be initialized\` at startup. The wrapper documents this in \`planning.launch.xml\`; resolving it requires either an upstream patch or forking the planning launch. Picked up during M4 live bring-up.

## Stack

Based on #6 (which is on #5, on #4). Final piece of the MVP code path — after this lands the remaining MVP work (Tasks 1-4, 11, 13, 16-19, 29-30, 35-37) is hardware / map-prep / live-validation that needs the physical robot.